### PR TITLE
edited how LinkedIn links work

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -48,7 +48,7 @@
 		{% endif %}
 		{% if site.author.linkedin %}
 		<li>
-			<a class="btn btn-default btn-sm" href="https://linkedin.com/pub/{{ site.author.linkedin }}">
+			<a class="btn btn-default btn-sm" href="https://linkedin.com/in/{{ site.author.linkedin }}">
 				<i class="fa fa-linkedin fa-lg"></i>
 			</a>
 		</li>


### PR DESCRIPTION
linkedin/pub/username doesn't go to the public profile on LinkedIn. The way this works is linkedin/in/vanityname. I just adjusted it to work correctly.
